### PR TITLE
Fix setuptools build error by specifying version of pip

### DIFF
--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -40,11 +40,9 @@ RUN apt-get update && \
     libboost-system1.58.0 \
     libboost-thread1.58.0 \
     && \
-    pip install --upgrade \
-        pip \
-        setuptools && \
-    pip install --upgrade \
-        supervisor && \
+    pip install --upgrade pip==9.0.3 && \
+    pip install --upgrade setuptools && \
+    pip install --upgrade supervisor && \
     mkdir -p \
         /etc/supervisor.d    \
         /etc/supervisor      \


### PR DESCRIPTION
Specify a specific version of pip in order to avoid error detail in the issue here:
https://github.com/yandex/yandex-tank/issues/845